### PR TITLE
Some routing parameter can be provided multiple times

### DIFF
--- a/src/tomtom_apis/routing/models.py
+++ b/src/tomtom_apis/routing/models.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 
@@ -33,12 +33,12 @@ class CalculateLongDistanceEVRouteParams(BaseParams):
     """Parameters for the calculate long distance EV route API."""
 
     vehicleHeading: int | None = None
-    sectionType: SectionType | None = None
+    sectionType: list[SectionType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     report: str | None = None
     departAt: str | None = None
     routeType: RouteType | None = None
     traffic: bool | None = None
-    avoid: AvoidType | None = None
+    avoid: list[AvoidType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     travelMode: TravelModeType | None = None
     vehicleMaxSpeed: int | None = None
     vehicleWeight: int | None = None
@@ -48,7 +48,7 @@ class CalculateLongDistanceEVRouteParams(BaseParams):
     vehicleWidth: float | None = None
     vehicleHeight: float | None = None
     vehicleCommercial: bool | None = None
-    vehicleLoadType: VehicleLoadType | None = None
+    vehicleLoadType: list[VehicleLoadType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     vehicleAdrTunnelRestrictionCode: AdrCategoryType | None = None
     vehicleEngineType: VehicleEngineType
     accelerationEfficiency: float | None = None
@@ -93,7 +93,7 @@ class CalculateReachableRouteParams(BaseParams):
     arriveAt: str | None = None
     routeType: RouteType | None = None
     traffic: bool | None = None
-    avoid: AvoidType | None = None
+    avoid: list[AvoidType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     travelMode: TravelModeType | None = None
     hilliness: HillinessType | None = None
     windingness: WindingnessType | None = None
@@ -105,7 +105,7 @@ class CalculateReachableRouteParams(BaseParams):
     vehicleWidth: float | None = None
     vehicleHeight: float | None = None
     vehicleCommercial: bool | None = None
-    vehicleLoadType: VehicleLoadType | None = None
+    vehicleLoadType: list[VehicleLoadType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     vehicleAdrTunnelRestrictionCode: AdrCategoryType | None = None
     constantSpeedConsumptionInLitersPerHundredkm: str | None = None
     currentFuelInLiters: float | None = None
@@ -135,13 +135,13 @@ class CalculateRouteParams(BaseParams):
     routeRepresentation: str | None = None
     computeTravelTimeFor: str | None = None
     vehicleHeading: int | None = None
-    sectionType: SectionType | None = None
+    sectionType: list[SectionType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     report: str | None = None
     departAt: str | None = None
     arriveAt: str | None = None
     routeType: RouteType | None = None
     traffic: bool | None = None
-    avoid: AvoidType | None = None
+    avoid: list[AvoidType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     travelMode: TravelModeType | None = None
     hilliness: HillinessType | None = None
     windingness: WindingnessType | None = None
@@ -153,7 +153,7 @@ class CalculateRouteParams(BaseParams):
     vehicleWidth: float | None = None
     vehicleHeight: float | None = None
     vehicleCommercial: bool | None = None
-    vehicleLoadType: VehicleLoadType | None = None
+    vehicleLoadType: list[VehicleLoadType] | None = field(default=None, metadata={"serialize": list})  # serialize as list, so the field repeats.
     vehicleAdrTunnelRestrictionCode: AdrCategoryType | None = None
     vehicleEngineType: VehicleEngineType | None = None
     constantSpeedConsumptionInLitersPerHundredkm: str | None = None

--- a/tests/routing/test_routing.py
+++ b/tests/routing/test_routing.py
@@ -102,7 +102,7 @@ async def test_deserialization_get_calculate_reachable_range(routing_api: Routin
         origin=LOC_AMSTERDAM,
         params=CalculateReachableRouteParams(
             energyBudgetInkWh=43,
-            avoid=AvoidType.UNPAVED_ROADS,
+            avoid=[AvoidType.UNPAVED_ROADS],
             vehicleEngineType=VehicleEngineType.ELECTRIC,
             constantSpeedConsumptionInkWhPerHundredkm="50,8.2:130,21.3",
         ),
@@ -125,7 +125,7 @@ async def test_deserialization_post_calculate_reachable_range(routing_api: Routi
         origin=LOC_AMSTERDAM,
         params=CalculateReachableRouteParams(
             energyBudgetInkWh=43,
-            avoid=AvoidType.UNPAVED_ROADS,
+            avoid=[AvoidType.UNPAVED_ROADS],
             vehicleEngineType=VehicleEngineType.ELECTRIC,
             constantSpeedConsumptionInkWhPerHundredkm="50,8.2:130,21.3",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->

The APIs handle lists differently, mostly as a comma-separated string, but these fields in the routing API need to repeat, therefore we need to specify a `serialize` function, in this case, the built-in `list`

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->
The following fields are now lists:

- CalculateLongDistanceEVRouteParams: `sectionType`, `avoid` and `vehicleLoadType`
- CalculateReachableRouteParams: `avoid` and `vehicleLoadType`
- CalculateRouteParams: `sectionType`, `avoid` and `vehicleLoadType`

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
