### PR TITLE
Don't automatically close the provided session

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,12 @@ session = ClientSession("https://api.tomtom.com", timeout=ClientTimeout(total=60
 
 # Create an instance of MapDisplayApi
 map_display_api = MapDisplayApi(options, session)
+
+# Use the API
+map_display_api.get_map_tile(...)
+
+# Close the session when done
+map_display_api.close()
 ```
 
 ## Sharing ClientSession Between APIs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ ignore = [
 ]
 "tests/**/*.py" = [
   "S101",  # Allow assertions in tests.
+  "SLF001",  # Allow access to private members in tests.
   "PLR2004",  # Allow magic numbers in tests.
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,7 +44,14 @@ def fixture_mock_response() -> AsyncMock:
 def fixture_mock_session(mock_response: AsyncMock) -> AsyncMock:
     """Fixture for mock session."""
     session = AsyncMock(spec=ClientSession)
+    session.closed = False
+
+    async def close_mock() -> None:
+        session.closed = True
+
+    session.close = AsyncMock(side_effect=close_mock)
     session.request = AsyncMock(return_value=mock_response)
+
     return session
 
 
@@ -284,9 +291,21 @@ async def test_tracking_id(base_api: BaseApi, mock_session: AsyncMock) -> None:
 
 
 async def test_manual_session_close(mock_session: AsyncMock) -> None:
-    """Test manual closing of the session."""
+    """Test manual closing of the provided session."""
     options = ApiOptions(api_key=API_KEY)
-    base_api = BaseApi(options, mock_session)
-    assert base_api.session is not None
+    async with BaseApi(options, mock_session) as base_api:
+        assert base_api._close_session  # pylint: disable=protected-access
+        assert not base_api.session.closed
+
     await base_api.close()
+    assert base_api.session.closed
+
+
+async def test_auto_session_close() -> None:
+    """Test auto closing of the default session."""
+    options = ApiOptions(api_key=API_KEY)
+    async with BaseApi(options) as base_api:
+        assert base_api._close_session  # pylint: disable=protected-access
+        assert not base_api.session.closed
+
     assert base_api.session.closed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
When a session is provided to one of the APIs, it shouldn't be automatically closed. The idea here is that the session can be used for several APIs or even within an application with other clients.

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->
Provided sessions need to be closed manually when done.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
