### PR TITLE
Do not use hardcoded Python and Node versions for CI

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -1,29 +1,19 @@
 name: Setup environment
 description: This action sets up the environment for the project.
 
-inputs:
-  python-version:
-    description: The version of Python to use.
-    required: true
-    default: "3.13"
-  node-version:
-    description: The version of Python to use.
-    required: true
-    default: "22"
-
 runs:
   using: composite
   steps:
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: ${{ inputs.python-version }}
         enable-cache: true
 
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version-file: package.json
+        cache: npm
 
     - name: Run setup_env script
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,6 @@ on: # yamllint disable-line rule:truthy
       - main
   pull_request: ~
 
-env:
-  DEFAULT_PYTHON: "3.13"
-  DEFAULT_NODE: "22"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -47,9 +43,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          node-version: ${{ env.DEFAULT_NODE }}
 
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}
@@ -67,9 +60,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          node-version: ${{ env.DEFAULT_NODE }}
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,6 @@ on: # yamllint disable-line rule:truthy
     types:
       - published
 
-env:
-  DEFAULT_PYTHON: "3.13"
-  DEFAULT_NODE: "22"
-
 permissions:
   contents: read
 
@@ -28,9 +24,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          node-version: ${{ env.DEFAULT_NODE }}
 
       - name: Set project version
         run: |

--- a/.github/workflows/update_fixtures.yaml
+++ b/.github/workflows/update_fixtures.yaml
@@ -10,10 +10,6 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 0 * * *" # Every day at UTC midnight.
 
-env:
-  DEFAULT_PYTHON: "3.13"
-  DEFAULT_NODE: "22"
-
 permissions:
   contents: read
 
@@ -38,9 +34,6 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          node-version: ${{ env.DEFAULT_NODE }}
 
       - name: Update fixtures script
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "prettier": "3.5.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Asynchronous Python client for the TomTom APIs",
   "author": "Sander Gols <developer@golles.nl>",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "devDependencies": {
     "prettier": "3.5.3"
   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->

Python version is defined in pyproject.toml, Node version in package.json and their lock files. With this proposed change, the versions are taken from these files instead of hardcoding them in the workflows.

The setup-env action gets the values from the files, so the inputs are no longer needed. The downside would be that we can't test against multiple versions (eg. via a matrix), but this was never a requirement and wasn't needed since the beginning of this project

Also enabled caching for node.

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
